### PR TITLE
Coletor CNJ: Erros com os metadados resolvido

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,12 @@
+et-xmlfile==1.0.1
 numpy==1.19.5
 openpyxl==3.0.7
 pandas==1.1.5
+python-dateutil==2.8.1
+pytz==2021.1
+selenium==3.141.0
+six==1.15.0
+urllib3==1.26.5
+xlrd==2.0.1
 protoDadosjusbr==0.6
 protobuf==3.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@ selenium==3.141.0
 six==1.15.0
 urllib3==1.26.5
 xlrd==2.0.1
-coleta-dadosjusbr==0.4
-protoDadosjusbr==0.5
+protoDadosjusbr==0.6
 protobuf==3.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,5 @@
-et-xmlfile==1.0.1
 numpy==1.19.5
 openpyxl==3.0.7
 pandas==1.1.5
-python-dateutil==2.8.1
-pytz==2021.1
-selenium==3.141.0
-six==1.15.0
-urllib3==1.26.5
-xlrd==2.0.1
 protoDadosjusbr==0.6
 protobuf==3.18.0

--- a/src/main.py
+++ b/src/main.py
@@ -45,7 +45,8 @@ else:
 
 # Main execution
 def main():
-    file_names = crawler.crawl(court, year, month, driver_path, output_path)
+    # file_names = crawler.crawl(court, year, month, driver_path, output_path)
+    file_names = [f.rstrip() for f in sys.stdin.readlines()]
 
     # Cria objeto com dados da coleta.
     coleta = Coleta.Coleta()


### PR DESCRIPTION
## Erros com os metadados
Depois de muitos teste, eu e @joaolgm, descobrimos que o erro dos metadados era por conta dos módulos, provavelmente eles estavam entrando em conflito, e a versão do **protoDadosjusbr** estava como **0.5** mas ela já está na versão **0.6**.

>Acabei me confundindo na hora de fazer o push para o repositório remoto, e acabei mandando tudo para a brach **main**, na tentativa de reverter isso, acabei revertendo um commit a mais, dentro da main. Esse **PR** resolve esses erros.

