### PR TITLE
Parser CNJ: Descontos com natureza "D"

### DIFF
--- a/src/output_test/test_parser/expected.json
+++ b/src/output_test/test_parser/expected.json
@@ -13,21 +13,25 @@
                         "valor": 30471.11
                     },
                     {
+                        "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Previdência Pública",
                         "valor": -4342.92
                     },
                     {
+                        "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Imposto de renda",
                         "valor": -7609.24
                     },
                     {
+                        "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Descontos Diversos",
                         "valor": -2735.4
                     },
                     {
+                        "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Retenção por Teto Constitucional"
                     },

--- a/src/output_test/test_parser/test_one_line/expected.json
+++ b/src/output_test/test_parser/test_one_line/expected.json
@@ -13,21 +13,25 @@
                         "valor": 5976300.680000007
                     },
                     {
+                        "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Previdência Pública",
                         "valor": -891368.0300000008
                     },
                     {
+                        "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Imposto de renda",
                         "valor": -1559437.48
                     },
                     {
+                        "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Descontos Diversos",
                         "valor": -863381.2400000002
                     },
                     {
+                        "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Retenção por Teto Constitucional"
                     },

--- a/src/parser_cnj.py
+++ b/src/parser_cnj.py
@@ -107,6 +107,7 @@ def cria_remuneracao(row, categoria):
             remuneracao.item = key
             remuneracao.valor = number.format_element(row[value])
             if categoria == CONTRACHEQUE and value in [8, 9, 10, 11]:
+                remuneracao.natureza = Coleta.Remuneracao.Natureza.Value("D")
                 remuneracao.valor = remuneracao.valor * (-1)
             remu_array.remuneracao.append(remuneracao)
 

--- a/src/test_data.py
+++ b/src/test_data.py
@@ -2,19 +2,19 @@ from data import load
 import unittest
 
 file_names = [
-    "./src/output_test/test_data/contracheque-tjpi-2019-03.xlsx",
-    "./src/output_test/test_data/direitos-pessoais-tjpi-2019-03.xlsx",
-    "./src/output_test/test_data/indenizacoes-tjpi-2019-03.xlsx",
-    "./src/output_test/test_data/direitos-eventuais-tjpi-2019-03.xlsx",
-    "./src/output_test/test_data/controle-de-arquivos-tjrr-2019-09.xlsx",
+    "output_test/test_data/contracheque-tjpi-2019-03.xlsx",
+    "output_test/test_data/direitos-pessoais-tjpi-2019-03.xlsx",
+    "output_test/test_data/indenizacoes-tjpi-2019-03.xlsx",
+    "output_test/test_data/direitos-eventuais-tjpi-2019-03.xlsx",
+    "output_test/test_data/controle-de-arquivos-tjrr-2019-09.xlsx",
 ]
 
 file_names_zeroless = [
-    "./src/output_test/test_data/contracheque-tjpe-2019-05.xlsx",
-    "./src/output_test/test_data/direitos-pessoais-tjpe-2019-05.xlsx",
-    "./src/output_test/test_data/indenizacoes-tjpe-2019-05.xlsx",
-    "./src/output_test/test_data/direitos-eventuais-tjpe-2019-05.xlsx",
-    "./src/output_test/test_data/controle-de-arquivos-tjpe-2019-05.xlsx",
+    "output_test/test_data/contracheque-tjpe-2019-05.xlsx",
+    "output_test/test_data/direitos-pessoais-tjpe-2019-05.xlsx",
+    "output_test/test_data/indenizacoes-tjpe-2019-05.xlsx",
+    "output_test/test_data/direitos-eventuais-tjpe-2019-05.xlsx",
+    "output_test/test_data/controle-de-arquivos-tjpe-2019-05.xlsx",
 ]
 
 

--- a/src/test_parser.py
+++ b/src/test_parser.py
@@ -24,7 +24,7 @@ class TestParser(unittest.TestCase):
         result_data = parse(dados, 'tjrj/01/2018')
         # Converto o resultado do parser, em dict
         result_to_dict = MessageToDict(result_data)
-
+        
         self.assertEqual(expected, result_to_dict)
 
 
@@ -44,7 +44,7 @@ class TestParser(unittest.TestCase):
         result_data = parse(dados, 'tjpi/01/2020')
         # Converto o resultado do parser, em dict
         result_to_dict = MessageToDict(result_data)
-
+        
         self.assertEqual(expected, result_to_dict)
 
 


### PR DESCRIPTION
## Descontos com natureza "D"
> Esse **PR** resolve a issue #27 

Foi necessário alterar os seguintes arquivos:
|Arquivo|Mudança|
|-|-|
|`parser_cnj.py`| Adicionado linha que diz o tipo da natureza em um `if`.|
|`expected.json`| Os dois arquivos de test com esse nome foram alterados, para corresponder ao formato com a natureza "D".|
|`test_data.py`| Caminho dos arquivos de test alterados para melhorar a execução.|