### PR TITLE
Parser CNJ: Pegando o tipo de receita

### DIFF
--- a/src/output_test/test_parser/expected.json
+++ b/src/output_test/test_parser/expected.json
@@ -16,109 +16,133 @@
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Previdência Pública",
-                        "valor": -4342.92
+                        "valor": -4342.92,
+                        "tipoReceita": "O"
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Imposto de renda",
-                        "valor": -7609.24
+                        "valor": -7609.24,
+                        "tipoReceita": "O"
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Descontos Diversos",
-                        "valor": -2735.4
+                        "valor": -2735.4,
+                        "tipoReceita": "O"
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
-                        "item": "Retenção por Teto Constitucional"
+                        "item": "Retenção por Teto Constitucional",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "contracheque",
-                        "item": "Remuneração do órgão de origem "
+                        "item": "Remuneração do órgão de origem ",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "contracheque",
-                        "item": "Diárias"
+                        "item": "Diárias",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
                         "item": "Auxílio-alimentação",
-                        "valor": 1825.0
+                        "valor": 1825.0,
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
-                        "item": "Auxílio Pré-escolar"
+                        "item": "Auxílio Pré-escolar",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
-                        "item": "Auxílio Saúde"
+                        "item": "Auxílio Saúde",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
-                        "item": "Auxílio Natalidade"
+                        "item": "Auxílio Natalidade",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
                         "item": "Auxílio Moradia",
-                        "valor": 4377.0
+                        "valor": 4377.0,
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
-                        "item": "Ajuda de Custo"
+                        "item": "Ajuda de Custo",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Abono constitucional de 1/3 de férias"
+                        "item": "Abono constitucional de 1/3 de férias",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Indenização de férias"
+                        "item": "Indenização de férias",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Antecipação de férias"
+                        "item": "Antecipação de férias",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Gratificação natalina"
+                        "item": "Gratificação natalina",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Antecipação de gratificação natalina"
+                        "item": "Antecipação de gratificação natalina",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Substituição"
+                        "item": "Substituição",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
                         "item": "Gratificação por exercício cumulativo",
-                        "valor": 10340.29
+                        "valor": 10340.29,
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Gratificação por encargo Curso/Concurso"
+                        "item": "Gratificação por encargo Curso/Concurso",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Pagamentos retroativos"
+                        "item": "Pagamentos retroativos",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "JETON"
+                        "item": "JETON",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-pessoais",
                         "item": "Abono de permanência",
-                        "valor": 4342.92
+                        "valor": 4342.92,
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-pessoais",
                         "item": "ARTIGO 95, III da CF",
-                        "valor": 549.76
+                        "valor": 549.76,
+                        "tipoReceita": "O"
                     }
                 ]
             }

--- a/src/output_test/test_parser/expected.json
+++ b/src/output_test/test_parser/expected.json
@@ -16,28 +16,24 @@
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Previdência Pública",
-                        "valor": -4342.92,
-                        "tipoReceita": "O"
+                        "valor": -4342.92
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Imposto de renda",
-                        "valor": -7609.24,
-                        "tipoReceita": "O"
+                        "valor": -7609.24
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Descontos Diversos",
-                        "valor": -2735.4,
-                        "tipoReceita": "O"
+                        "valor": -2735.4
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
-                        "item": "Retenção por Teto Constitucional",
-                        "tipoReceita": "O"
+                        "item": "Retenção por Teto Constitucional"
                     },
                     {
                         "categoria": "contracheque",

--- a/src/output_test/test_parser/test_one_line/expected.json
+++ b/src/output_test/test_parser/test_one_line/expected.json
@@ -16,100 +16,123 @@
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Previdência Pública",
-                        "valor": -891368.0300000008
+                        "valor": -891368.0300000008,
+                        "tipoReceita": "O"
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Imposto de renda",
-                        "valor": -1559437.48
+                        "valor": -1559437.48,
+                        "tipoReceita": "O"
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Descontos Diversos",
-                        "valor": -863381.2400000002
+                        "valor": -863381.2400000002,
+                        "tipoReceita": "O"
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
-                        "item": "Retenção por Teto Constitucional"
+                        "item": "Retenção por Teto Constitucional",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "contracheque",
-                        "item": "Remuneração do órgão de origem "
+                        "item": "Remuneração do órgão de origem ",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "contracheque",
-                        "item": "Diárias"
+                        "item": "Diárias",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
-                        "item": "Auxílio-alimentação"
+                        "item": "Auxílio-alimentação",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
-                        "item": "Auxílio Pré-escolar"
+                        "item": "Auxílio Pré-escolar",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
-                        "item": "Auxílio Saúde"
+                        "item": "Auxílio Saúde",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
-                        "item": "Auxílio Natalidade"
+                        "item": "Auxílio Natalidade",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
-                        "item": "Auxílio Moradia"
+                        "item": "Auxílio Moradia",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "indenizações",
-                        "item": "Ajuda de Custo"
+                        "item": "Ajuda de Custo",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Abono constitucional de 1/3 de férias"
+                        "item": "Abono constitucional de 1/3 de férias",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Indenização de férias"
+                        "item": "Indenização de férias",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Antecipação de férias"
+                        "item": "Antecipação de férias",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Gratificação natalina"
+                        "item": "Gratificação natalina",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Antecipação de gratificação natalina"
+                        "item": "Antecipação de gratificação natalina",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Substituição"
+                        "item": "Substituição",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Gratificação por exercício cumulativo"
+                        "item": "Gratificação por exercício cumulativo",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Gratificação por encargo Curso/Concurso"
+                        "item": "Gratificação por encargo Curso/Concurso",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "Pagamentos retroativos"
+                        "item": "Pagamentos retroativos",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-eventuais",
-                        "item": "JETON"
+                        "item": "JETON",
+                        "tipoReceita": "O"
                     },
                     {
                         "categoria": "direitos-pessoais",
-                        "item": "Abono de permanência"
+                        "item": "Abono de permanência",
+                        "tipoReceita": "O"
                     }
                 ]
             }

--- a/src/output_test/test_parser/test_one_line/expected.json
+++ b/src/output_test/test_parser/test_one_line/expected.json
@@ -16,28 +16,24 @@
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Previdência Pública",
-                        "valor": -891368.0300000008,
-                        "tipoReceita": "O"
+                        "valor": -891368.0300000008
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Imposto de renda",
-                        "valor": -1559437.48,
-                        "tipoReceita": "O"
+                        "valor": -1559437.48
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Descontos Diversos",
-                        "valor": -863381.2400000002,
-                        "tipoReceita": "O"
+                        "valor": -863381.2400000002
                     },
                     {
                         "natureza": "D",
                         "categoria": "contracheque",
-                        "item": "Retenção por Teto Constitucional",
-                        "tipoReceita": "O"
+                        "item": "Retenção por Teto Constitucional"
                     },
                     {
                         "categoria": "contracheque",

--- a/src/parser_cnj.py
+++ b/src/parser_cnj.py
@@ -22,6 +22,7 @@ def cria_remuneracao(row, categoria):
     if categoria == DIREITOS_PESSOAIS:
         key, value = "Abono de permanência", row[3]
         remuneracao = Coleta.Remuneracao()
+        remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
         remuneracao.item = key
         remuneracao.valor = number.format_element(value)
         remuneracao.categoria = categoria
@@ -30,6 +31,7 @@ def cria_remuneracao(row, categoria):
         key, value = str(row[5]), row[4]
         if key != '0' and key != '0.0' and key != '-':
             remuneracao = Coleta.Remuneracao()
+            remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
             remuneracao.item = key
             remuneracao.valor = number.format_element(value)
             remuneracao.categoria = categoria
@@ -38,6 +40,7 @@ def cria_remuneracao(row, categoria):
         key, value = str(row[7]), row[6]
         if key != '0' and key != '0.0' and key != '-':
             remuneracao = Coleta.Remuneracao()
+            remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
             remuneracao.item = key
             remuneracao.valor = number.format_element(value)
             remuneracao.categoria = categoria
@@ -59,6 +62,7 @@ def cria_remuneracao(row, categoria):
             if str(row[10]) != '0' and str(row[10]) != '0.0' and str(row[10]) != '-':
                 remuneracao = Coleta.Remuneracao()
                 remuneracao.natureza = Coleta.Remuneracao.Natureza.Value("R")
+                remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
                 remuneracao.categoria = categoria
                 remuneracao.item = row[10]
                 remuneracao.valor = number.format_element(row[9])
@@ -67,6 +71,7 @@ def cria_remuneracao(row, categoria):
             if str(row[12]) != '0' and str(row[12]) != '0.0' and str(row[12]) != '-':
                 remuneracao = Coleta.Remuneracao()
                 remuneracao.natureza = Coleta.Remuneracao.Natureza.Value("R")
+                remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
                 remuneracao.categoria = categoria
                 remuneracao.item = row[12]
                 remuneracao.valor = number.format_element(row[11])
@@ -75,6 +80,7 @@ def cria_remuneracao(row, categoria):
             if str(row[14]) != '0' and str(row[14]) != '0.0' and str(row[14]) != '-':
                 remuneracao = Coleta.Remuneracao()
                 remuneracao.natureza = Coleta.Remuneracao.Natureza.Value("R")
+                remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
                 remuneracao.categoria = categoria
                 remuneracao.item = row[14]
                 remuneracao.valor = number.format_element(row[13])
@@ -84,6 +90,7 @@ def cria_remuneracao(row, categoria):
             if str(row[14]) != '0' and str(row[14]) != '0.0' and str(row[14]) != '-':
                 remuneracao = Coleta.Remuneracao()
                 remuneracao.natureza = Coleta.Remuneracao.Natureza.Value("R")
+                remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
                 remuneracao.categoria = categoria
                 remuneracao.item = row[14]
                 remuneracao.valor = number.format_element(row[13])
@@ -94,6 +101,7 @@ def cria_remuneracao(row, categoria):
             if str(row[16]) != '0' and str(row[16]) != '0.0' and str(row[16]) != '-':
                 remuneracao = Coleta.Remuneracao()
                 remuneracao.natureza = Coleta.Remuneracao.Natureza.Value("R")
+                remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
                 remuneracao.categoria = categoria
                 remuneracao.item = row[16]
                 remuneracao.valor = number.format_element(row[15])
@@ -103,9 +111,12 @@ def cria_remuneracao(row, categoria):
         else:
             remuneracao = Coleta.Remuneracao()
             remuneracao.natureza = Coleta.Remuneracao.Natureza.Value("R")
+            remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
             remuneracao.categoria = categoria
             remuneracao.item = key
             remuneracao.valor = number.format_element(row[value])
+            if categoria == CONTRACHEQUE and value == 3:
+                remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("B")
             if categoria == CONTRACHEQUE and value in [8, 9, 10, 11]:
                 remuneracao.natureza = Coleta.Remuneracao.Natureza.Value("D")
                 remuneracao.valor = remuneracao.valor * (-1)

--- a/src/parser_cnj.py
+++ b/src/parser_cnj.py
@@ -111,15 +111,16 @@ def cria_remuneracao(row, categoria):
         else:
             remuneracao = Coleta.Remuneracao()
             remuneracao.natureza = Coleta.Remuneracao.Natureza.Value("R")
-            remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
             remuneracao.categoria = categoria
             remuneracao.item = key
             remuneracao.valor = number.format_element(row[value])
-            if categoria == CONTRACHEQUE and value == 3:
-                remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("B")
             if categoria == CONTRACHEQUE and value in [8, 9, 10, 11]:
                 remuneracao.natureza = Coleta.Remuneracao.Natureza.Value("D")
                 remuneracao.valor = remuneracao.valor * (-1)
+            else:
+                remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("O")
+            if categoria == CONTRACHEQUE and value == 3:
+                remuneracao.tipo_receita = Coleta.Remuneracao.TipoReceita.Value("B")
             remu_array.remuneracao.append(remuneracao)
 
     return remu_array


### PR DESCRIPTION
## Pegando o tipo de receita
> Esse **PR** resolve a issue #28 

Foi necessário alterar os seguintes arquivos:
|Arquivo|Mudança|
|-|-|
|`parser_cnj.py`| Adicionado linhas que informam o tipo de receita.|
|`expected.json`| Os dois arquivos de test com esse nome foram alterados, para corresponder ao formato com com tipo de receita.|