### PR TITLE
validando o órgão

### DIFF
--- a/src/parser_cnj.py
+++ b/src/parser_cnj.py
@@ -162,13 +162,14 @@ def cria_remuneracao(row, categoria):
     return remu_array, sem_detalhamento
 
 
-def parse_employees(fn, chave_coleta):
+def parse_employees(fn, chave_coleta, court):
     employees = {}
     counter = 1
     for row in fn:
         name = row[1]
         # Usa-se o isNaN para não pegar linhas vázias.
-        if not number.is_nan(name):
+        # A segunda condição verifica se o membro pertence ao órgão.
+        if not number.is_nan(name) and row[0].casefold() == court.casefold():
             membro = Coleta.ContraCheque()
             membro.id_contra_cheque = chave_coleta + "/" + str(counter)
             membro.chave_coleta = chave_coleta
@@ -202,7 +203,7 @@ def parse(data, chave_coleta):
         # Cria a base com o contracheque, depois vai ser atualizado com
         # as outras planilhas.
         contracheques, sem_detalhamento = parse_employees(
-            data.contracheque, chave_coleta)
+            data.contracheque, chave_coleta, data.court)
         employees.update(contracheques)
 
         _, sem_detalhamento = update_employees(


### PR DESCRIPTION
- Algumas coletas, i.e. TRT1 e TRT2, retornam dados de outros tribunais que tbm contenham a sua sigla - e.g. TRT10, TRT11... TRT19, TRT20..., TRT24.
- Com essa modificação, validamos se cada membro pertence de fato ao órgão.