### PR TITLE
verifica se há números na string

### DIFF
--- a/src/number.py
+++ b/src/number.py
@@ -1,9 +1,11 @@
+import re
+
 def is_nan(string):
     return string != string
 
 def format_element(element):
     # A value was found with incorrect formatting. (3,045.99 instead of 3045.99)
-    if is_nan(element):
+    if is_nan(element) or not re.search(r'\d', str(element)):
         return 0.0
     if type(element) == str:
         if "." in element and "," in element:


### PR DESCRIPTION
- erro de coleta: ValueError: could not convert string to float: 'TJRR'
- órgão colocou 'TJRR' em vez de número em coluna referente a antecipação de férias
- verifica se há números na string (ex.: "54.321,00") ou apenas caracteres (ex.: "TJRR" ou " - ")